### PR TITLE
Added a note in README on how to use HOOT in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ If you use the HOOT Benchmark or the toolkit for a research publication, please 
 
 ## Getting Started
 
+> [NOTE!] 
+> before using hoot in windows, turn off the smart app control.
+
 1. View the CLI command listing
    ```sh
    hoot --help


### PR DESCRIPTION
hoot cli doesn't work in Windows when Smart App Control is on.